### PR TITLE
Added Python 3.x support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
I installed the library using a Python 3.4 virtual environment and started my website project using django-crispy-forms on it ; it worked like a charm and without any more modifications than the `setup.py` file in order to install it locally with Pip.

Here is an attached image of django-debug-toolbar on a page displaying a cripsy-generated form:

![Screen capture showing both Python 3.4 and crispy-forms-foundation running together](https://cloud.githubusercontent.com/assets/989521/3805620/707def04-1c3a-11e4-9eac-e001c677952a.png)
