### PR TITLE
Allow unicode characters in the form title

### DIFF
--- a/crispy_forms_foundation/forms.py
+++ b/crispy_forms_foundation/forms.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django import forms
 from django.core.urlresolvers import reverse, NoReverseMatch
 from crispy_forms.helper import FormHelper
@@ -37,7 +38,7 @@ class FoundationFormMixin(object):
             self.helper.layout = self.layout
 
         if self.title:
-            self.helper.layout.insert(0, HTML("<h3 class=\"subheader\">{0}</h3>".format(self.title)))
+            self.helper.layout.insert(0, HTML(u"<h3 class=\"subheader\">{0}</h3>".format(self.title)))
         self.helper.form_id = self.id
         self.helper.form_class = self.classes
         try:


### PR DESCRIPTION
Using utf-8 encoded unicode characters in the title attribute resulted in a ascii encode error. This commit sould fix this.
