### PR TITLE
[WIP] Foundation 6 support

### DIFF
--- a/crispy_forms_foundation/layout/containers.py
+++ b/crispy_forms_foundation/layout/containers.py
@@ -70,7 +70,8 @@ class TabHolder(crispy_forms_bootstrap.TabHolder):
             tab.active = False
 
         # The first tab with errors will be active
-        self.first_container_with_errors(form.errors.keys()).active = True
+        if self.first_container_with_errors(form.errors.keys()) is not None:
+            self.first_container_with_errors(form.errors.keys()).active = True
 
         for tab in self.fields:
             content += render_field(
@@ -142,8 +143,9 @@ class AccordionHolder(crispy_forms_bootstrap.Accordion):
         if not self.css_id:
             self.css_id = "-".join(["accordion", text_type(randint(1000, 9999))])
 
-        # first group with errors or first groupt will be visible, others will be collapsed
-        self.first_container_with_errors(form.errors.keys()).active = True
+        # first group with errors or first group will be visible, others will be collapsed
+        if self.first_container_with_errors(form.errors.keys()) is not None:
+            self.first_container_with_errors(form.errors.keys()).active = True
 
         for group in self.fields:
             group.data_parent = self.css_id

--- a/crispy_forms_foundation/layout/fields.py
+++ b/crispy_forms_foundation/layout/fields.py
@@ -114,6 +114,8 @@ class SwitchField(crispy_forms_layout.Field):
 
     def __init__(self, field, *args, **kwargs):
         self.switch_class = ['switch'] + kwargs.pop('switch_class', '').split()
+        kwargs['class'] = (kwargs.pop('class', '') + ' switch-input').strip()
+
         super(SwitchField, self).__init__(field, *args, **kwargs)
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
@@ -147,6 +149,7 @@ class InlineSwitchField(InlineField):
         self.switch_class = ['switch']+kwargs.pop('switch_class', '').split()
         kwargs['label_column'] = kwargs.pop('label_column', 'large-8')
         kwargs['input_column'] = kwargs.pop('input_column', 'large-4')
+        kwargs['class'] = (kwargs.pop('class', '') + ' switch-input').strip()
 
         super(InlineSwitchField, self).__init__(field, *args, **kwargs)
 

--- a/crispy_forms_foundation/templates/foundation-5/field.html
+++ b/crispy_forms_foundation/templates/foundation-5/field.html
@@ -38,7 +38,7 @@
         {% endif %}
 
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     {% endspaceless %}</div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/field.html
+++ b/crispy_forms_foundation/templates/foundation-5/field.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="holder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
+    <div id="div_{{ field.auto_id }}" class="holder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} callout alert{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
 
         {% if field.label %}
             {% if field|is_checkbox %}
@@ -24,14 +24,14 @@
         {% endif %}
 
         {% if field.field.abide_msg %}
-            <small id="abide_error_{{ field.auto_id }}" class="error {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
+            <small id="abide_error_{{ field.auto_id }}" class="alert label {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
                 {{ field.field.abide_msg }}
             </small>
         {% endif %}
 
         {% if form_show_errors %}
             {% for error in field.errors %}
-                <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error {% if not forloop.last %}compact{% endif %}">
+                <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label {% if not forloop.last %}compact{% endif %}">
                     {{ error }}
                 </small>
             {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/field.strict.html
+++ b/crispy_forms_foundation/templates/foundation-5/field.strict.html
@@ -26,7 +26,7 @@
         {% endfor %}
 
         {% if field.help_text %}
-            <p id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</p>
+            <p id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</p>
         {% endif %}
     </div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/field.strict.html
+++ b/crispy_forms_foundation/templates/foundation-5/field.strict.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="holder{% if field.errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="holder{% if field.errors %} callout alert{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field|is_checkbox %}
             {% crispy_field field %}
@@ -20,7 +20,7 @@
         {% endif %}
 
         {% for error in field.errors %}
-            <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error">
+            <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label">
                 {{ error }}
             </small>
         {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/inline_switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/inline_switch.html
@@ -18,13 +18,13 @@
 
                 <label class="{% if field.field.required %}required{% endif %}" for="{{ field.id_for_label }}"></label>
                 {% if field.field.abide_msg %}
-                    <small id="abide_error_{{ field.auto_id }}" class="error {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
+                    <small id="abide_error_{{ field.auto_id }}" class="alert label {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
                         {{ field.field.abide_msg }}
                     </small>
                 {% endif %}
                 {% if form_show_errors %}
                     {% for error in field.errors %}
-                        <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error {% if not forloop.last %}compact{% endif %}">
+                        <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label {% if not forloop.last %}compact{% endif %}">
                             {{ error }}
                         </small>
                     {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/inline_switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/inline_switch.html
@@ -16,7 +16,9 @@
                     {% crispy_field field %}
                 {% endif %}
 
-                <label class="{% if field.field.required %}required{% endif %}" for="{{ field.id_for_label }}"></label>
+                <label class="switch-paddle{% if field.field.required %} required{% endif %}" for="{{ field.id_for_label }}">
+                    <span class="show-for-sr">{{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}</span>
+                </label>
                 {% if field.field.abide_msg %}
                     <small id="abide_error_{{ field.auto_id }}" class="alert label {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
                         {{ field.field.abide_msg }}

--- a/crispy_forms_foundation/templates/foundation-5/inline_switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/inline_switch.html
@@ -34,7 +34,7 @@
 
 
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     {% endspaceless %}</div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/accordion-holder.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/accordion-holder.html
@@ -1,4 +1,3 @@
-<dl class="accordion" id="{{ accordion.css_id }}" data-accordion>
-    <dt class="hide"></dt>
+<ul class="accordion" id="{{ accordion.css_id }}" data-accordion>
     {{ content|safe }}
-</dl>
+</ul>

--- a/crispy_forms_foundation/templates/foundation-5/layout/accordion-item.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/accordion-item.html
@@ -1,6 +1,6 @@
-<dd class="accordion-navigation">
-    <a href="#{{ div.css_id }}">{{ div.name|capfirst }}{% if div.item_has_errors %} <span class="label alert round mark">!</span>{% endif %}</a>
-    <div id="{{ div.css_id }}" class="content{% if div.active %} active{% endif %}">
+<li class="accordion-item{% if div.active %} is-active{% endif %}">
+    <a class="accordion-title">{{ div.name|capfirst }}{% if div.item_has_errors %} <span class="label alert round mark">!</span>{% endif %}</a>
+    <div class="accordion-content" data-tab-content>
         {{ fields|safe }}
     </div>
-</dd>
+</li>

--- a/crispy_forms_foundation/templates/foundation-5/layout/accordion-item.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/accordion-item.html
@@ -1,5 +1,5 @@
 <li class="accordion-item{% if div.active %} is-active{% endif %}">
-    <a class="accordion-title">{{ div.name|capfirst }}{% if div.item_has_errors %} <span class="label alert round mark">!</span>{% endif %}</a>
+    <a class="accordion-title">{{ div.name|capfirst }}{% if div.item_has_errors %} <span class="alert badge">!</span>{% endif %}</a>
     <div class="accordion-content" data-tab-content>
         {{ fields|safe }}
     </div>

--- a/crispy_forms_foundation/templates/foundation-5/layout/fieldset.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/fieldset.html
@@ -1,4 +1,4 @@
 <fieldset{% if fieldset.css_id %} id="{{ fieldset.css_id }}"{% endif %} class="fieldset{% if fieldset.css_class or form_style %} {{ fieldset.css_class }} {{ form_style }}{% endif %}" {{ fieldset.flat_attrs|safe }}>
-    <legend>{{ legend|safe }}</legend>
-    {{ fields|safe }}
+    <legend>{{ legend|safe }}</legend> 
+    {{ fields|safe }} 
 </fieldset>

--- a/crispy_forms_foundation/templates/foundation-5/layout/fieldset.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/fieldset.html
@@ -1,4 +1,4 @@
-<fieldset{% if fieldset.css_id %} id="{{ fieldset.css_id }}"{% endif %}{% if fieldset.css_class or form_style %} class="{{ fieldset.css_class }} {{ form_style }}"{% endif %} {{ fieldset.flat_attrs|safe }}>
-    <legend>{{ legend|safe }}</legend> 
-    {{ fields|safe }} 
+<fieldset{% if fieldset.css_id %} id="{{ fieldset.css_id }}"{% endif %} class="fieldset{% if fieldset.css_class or form_style %} {{ fieldset.css_class }} {{ form_style }}{% endif %}" {{ fieldset.flat_attrs|safe }}>
+    <legend>{{ legend|safe }}</legend>
+    {{ fields|safe }}
 </fieldset>

--- a/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="row inline-field{% if field|is_checkbox %} inline-checkbox{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="row inline-field{% if field|is_checkbox %} inline-checkbox{% endif %}{% if field.errors and form_show_errors %} callout alert{% endif %}">
         <div class="{{ label_column }}">
             <label for="{{ field.id_for_label }}" class="{{ label_class }}{% if field.field.required %} required{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}
@@ -27,7 +27,7 @@
         </div>
 
         {% if field.help_text %}
-            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text column">{{ field.help_text|safe }}</div>
         {% endif %}
     </div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
@@ -27,7 +27,7 @@
         </div>
 
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     </div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/inline_field.html
@@ -13,13 +13,13 @@
             {% crispy_field field %}
 
             {% if field.field.abide_msg %}
-                <small id="abide_error_{{ field.auto_id }}" class="error {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
+                <small id="abide_error_{{ field.auto_id }}" class="alert label {% if form_show_errors and not field.errors|length_is:"0" %}compact{% endif %}">
                     {{ field.field.abide_msg }}
                 </small>
             {% endif %}
             {% if form_show_errors %}
                 {% for error in field.errors %}
-                    <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error {% if not forloop.last %}compact{% endif %}">
+                    <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label {% if not forloop.last %}compact{% endif %}">
                         {{ error }}
                     </small>
                 {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/multifield.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/multifield.html
@@ -3,7 +3,7 @@
         {% for field in multifield.bound_fields %}
             {% if field.errors %}
                 {% for error in field.errors %}
-                    <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error">{{ error }}</p>
+                    <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label">{{ error }}</p>
                 {% endfor %}
             {% endif %}
         {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/multifield.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/multifield.html
@@ -19,7 +19,7 @@
 
     {% spaceless %}{% for field in multifield.bound_fields %}
         {% if field.help_text %}
-            <p id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</p>
+            <p id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</p>
         {% endif %}
     {% endfor %}{% endspaceless %}
 </div>

--- a/crispy_forms_foundation/templates/foundation-5/layout/splitdatetime_field.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/splitdatetime_field.html
@@ -3,10 +3,10 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="holder datetimesplit{% if field.errors and form_show_errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
+    <div id="div_{{ field.auto_id }}" class="holder datetimesplit{% if field.errors and form_show_errors %} callout alert{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
         {% if form_show_errors %}
             {% for error in field.errors %}
-                <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error">
+                <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label">
                     {{ error }}
                 </p>
             {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/layout/splitdatetime_field.html
+++ b/crispy_forms_foundation/templates/foundation-5/layout/splitdatetime_field.html
@@ -27,7 +27,7 @@
         </div>{% endif %}
 
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     {% endspaceless %}</div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/multifield.html
+++ b/crispy_forms_foundation/templates/foundation-5/multifield.html
@@ -11,9 +11,9 @@
         {% endif %}
 
         {% crispy_field field %}
-        
+
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     </div>
 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-5/switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/switch.html
@@ -11,9 +11,8 @@
                     {% crispy_field field %}
                 {% endif %}
 
-                <label for="{{ field.id_for_label }}" {% if field.field.required %}class="required"{% endif %}>
-                    {{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}
-                </label>
+                <label>{{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}</label>
+                <label class="switch-paddle{% if field.field.required %} required{% endif %}" for="{{ field.id_for_label }}"></label>
             </div> 
         {% endif %}
 

--- a/crispy_forms_foundation/templates/foundation-5/switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/switch.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="holder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
+    <div id="div_{{ field.auto_id }}" class="holder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} callout alert{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
 
         {% if field.label %}
             <div class="{{ switch_class }}">
@@ -27,7 +27,7 @@
 
         {% if form_show_errors %}
             {% for error in field.errors %}
-                <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error">
+                <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="alert label">
                     {{ error }}
                 </small>
             {% endfor %}

--- a/crispy_forms_foundation/templates/foundation-5/switch.html
+++ b/crispy_forms_foundation/templates/foundation-5/switch.html
@@ -34,7 +34,7 @@
         {% endif %}
 
         {% if field.help_text %}
-            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+            <div id="helptext_{{ field.auto_id }}" class="help-text">{{ field.help_text|safe }}</div>
         {% endif %}
     {% endspaceless %}</div>
 {% endif %}


### PR DESCRIPTION
**Work in progress, don't merge (yet)!**

This PR is meant as a collection of required changes required for Foundation 6 support.
I've not gone thoroughly through the Foundation changelog yet. Instead I'm currently just fixing things whenever I stumble upon something that does not seem to work properly in my current Django + Foundation 6 project.

_Also, to make it easier to spot the differences, I the template pack still is named `foundation-5`. This of course has to be moved to `foundation-6` prior to an eventual merge._
## Things changed
- [x] `<fieldset>` classes
- [x] `.hint` → `.help-text`
- [x] error styling
- [x] new [Switch](http://foundation.zurb.com/sites/docs/switch.html) markup (`<checkbox class="switch-input">` and `<label class="switch-paddle">`)
- [x] Accordion
## Issues found, but not yet addressed
- [ ] `aria-describedby` attribute for inputs with [help text](http://foundation.zurb.com/sites/docs/forms.html#help-text)
- [ ] Tabs
- [ ] Abide
