### PR TITLE
Abide bug with Foundation 6.4.1

### DIFF
--- a/crispy_forms_foundation/templates/foundation-6/field.html
+++ b/crispy_forms_foundation/templates/foundation-6/field.html
@@ -24,7 +24,7 @@
         {% endif %}
 
         {% if field.field.abide_msg %}
-            <span id="abide_error_{{ field.auto_id }}" class="form-error is-visible{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}">
+            <span id="abide_error_{{ field.auto_id }}" class="form-error{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}" data-form-error-for="{{ field.id_for_label }}">
                 {{ field.field.abide_msg }}
             </span>
         {% endif %}

--- a/crispy_forms_foundation/templates/foundation-6/inline_switch.html
+++ b/crispy_forms_foundation/templates/foundation-6/inline_switch.html
@@ -20,7 +20,7 @@
                     <span class="show-for-sr">{{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}</span>
                 </label>
                 {% if field.field.abide_msg %}
-                <span id="abide_error_{{ field.auto_id }}" class="form-error is-visible{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}">
+                <span id="abide_error_{{ field.auto_id }}" class="form-error{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}" data-form-error-for="{{ field.id_for_label }}">
                     {{ field.field.abide_msg }}
                 </span>
                 {% endif %}

--- a/crispy_forms_foundation/templates/foundation-6/layout/inline_field.html
+++ b/crispy_forms_foundation/templates/foundation-6/layout/inline_field.html
@@ -13,7 +13,7 @@
             {% crispy_field field %}
 
             {% if field.field.abide_msg %}
-                <span id="abide_error_{{ field.auto_id }}" class="form-error is-visible{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}">
+                <span id="abide_error_{{ field.auto_id }}" class="form-error{% if form_show_errors and not field.errors|length_is:"0" %} compact{% endif %}" data-form-error-for="{{ field.id_for_label }}">
                     {{ field.field.abide_msg }}
                 </span>
             {% endif %}


### PR DESCRIPTION
I'm not sure whether this worked in versions prior to 6.4.1 as I've only just started using Abide but having the "is-visible" class in the abide-only error sections means the errors are always displayed as opposed to appearing and disappearing as the content changes or the form is submitted. I've also added in the "data-form-error-for" attribute for completeness. 

http://foundation.zurb.com/sites/docs/abide.html#form-errors