### PR TITLE
From Django 1.11 render_to_string doesn't accept a Context.

### DIFF
--- a/crispy_forms_foundation/layout/buttons.py
+++ b/crispy_forms_foundation/layout/buttons.py
@@ -100,10 +100,19 @@ class ButtonGroup(crispy_forms_layout.LayoutObject):
                              template_pack=template_pack)
             )
 
-        return render_to_string(template, Context({
-            'buttongroup': self,
-            'field_list': field_list,
-        }))
+        try:
+            buttons = render_to_string(template, Context({
+                'buttongroup': self,
+                'field_list': field_list,
+            }))
+        except TypeError:
+            # From Django 1.11 render_to_string doesn't want a Context object
+            buttons = render_to_string(template, {
+                'buttongroup': self,
+                'field_list': field_list,
+            })
+
+        return buttons
 
 
 class InputButton(crispy_forms_layout.BaseInput):

--- a/project_test/tests/002_layout.py
+++ b/project_test/tests/002_layout.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-
+from django.test.html import parse_html
 from crispy_forms_foundation.layout import (Layout, Row, Column, ButtonHolder,
                                             Submit)
 
@@ -19,7 +19,7 @@ def test_basic(output_test_path, render_output, rendered_template, helper, clien
                                            "test_basic.html"))
     #write_output(output_test_path, pack, "test_basic.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_layout(output_test_path, render_output, rendered_template, helper, client):
@@ -32,7 +32,7 @@ def test_layout(output_test_path, render_output, rendered_template, helper, clie
                                            "test_layout.html"))
     #write_output(output_test_path, pack, "test_layout.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_advanced(output_test_path, render_output, rendered_template, helper, client):
@@ -69,4 +69,4 @@ def test_advanced(output_test_path, render_output, rendered_template, helper, cl
                                            "test_advanced.html"))
     #write_output(output_test_path, pack, "test_advanced.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)

--- a/project_test/tests/003_fields.py
+++ b/project_test/tests/003_fields.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-
+from django.test.html import parse_html
 from crispy_forms_foundation.layout import (Layout, InlineField,
                                             InlineSwitchField, FakeField)
 
@@ -24,7 +24,7 @@ def test_fakefield(output_test_path, render_output, rendered_template,
                                            "test_fakefield.html"))
     #write_output(output_test_path, pack, "test_fakefield.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_inlinefield(output_test_path, render_output, rendered_template,
@@ -43,7 +43,7 @@ def test_inlinefield(output_test_path, render_output, rendered_template,
                                            "test_inlinefield.html"))
     #write_output(output_test_path, pack, "test_inlinefield.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_inlineswitchfield(output_test_path, render_output, rendered_template,
@@ -63,4 +63,4 @@ def test_inlineswitchfield(output_test_path, render_output, rendered_template,
                                            "test_inlineswitchfield.html"))
     #write_output(output_test_path, pack, "test_inlineswitchfield.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)

--- a/project_test/tests/004_buttons.py
+++ b/project_test/tests/004_buttons.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-
+from django.test.html import parse_html
 from crispy_forms_foundation.layout import (Layout, ButtonGroup,
                                             Submit, Button,
                                             ButtonElement, ButtonSubmit)
@@ -29,7 +29,7 @@ def test_buttongroup(output_test_path, render_output, rendered_template,
                                            "test_buttongroup.html"))
     #write_output(output_test_path, pack, "test_buttongroup.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_buttonelement(output_test_path, render_output, rendered_template,

--- a/project_test/tests/005_containers.py
+++ b/project_test/tests/005_containers.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from django.test.html import parse_html
 
 from crispy_forms_foundation.layout import (Layout, TabHolder, TabItem,
                                             AccordionHolder, AccordionItem)
@@ -29,7 +30,7 @@ def test_tab(output_test_path, render_output, rendered_template, helper,
                                            "test_tab.html"))
     #write_output(output_test_path, pack, "test_tab.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)
 
 
 def test_accordion(output_test_path, render_output, rendered_template, helper,
@@ -53,4 +54,4 @@ def test_accordion(output_test_path, render_output, rendered_template, helper,
                                            "test_accordion.html"))
     #write_output(output_test_path, pack, "test_accordion.html", rendered)
 
-    assert attempted == rendered
+    assert parse_html(attempted) == parse_html(rendered)


### PR DESCRIPTION
render_to_string fails with a TypeError from Django 1.11.

To make the tests pass it was needed to compare the HTML after parsing it with django.tests.html.parse_html function, as the attributes were scrambled.