### PR TITLE
Removing required='' for FileFields that have a value set

### DIFF
--- a/crispy_forms_foundation/forms.py
+++ b/crispy_forms_foundation/forms.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 from django import forms
 from django.core.urlresolvers import reverse, NoReverseMatch
-from django.forms.fields import FileField
+from django.forms.fields import FileField, ImageField
 from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.helper import FormHelper
@@ -71,7 +71,7 @@ class FoundationFormMixin(object):
                     field_value = getattr(self.instance, field_name, None)
                 else:
                     field_value = None
-                if field.required and not (isinstance(field, FileField) and field_value):
+                if field.required and not ((isinstance(field, FileField) or isinstance(field, ImageField)) and field_value):
                     field.widget.attrs["required"] = ""
                     field.abide_msg = _("This field is required.")
 

--- a/crispy_forms_foundation/forms.py
+++ b/crispy_forms_foundation/forms.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 from django import forms
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.forms.fields import FileField
 from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.helper import FormHelper
@@ -65,8 +66,9 @@ class FoundationFormMixin(object):
         # Put required HTML attribute on required fields so they are managed by
         # Abide (if enabled)
         if "data_abide" in self.attrs:
-            for field in self.fields.values():
-                if field.required:
+            for field_name, field in self.fields.items():
+                field_value = getattr(self.instance, field_name, None)
+                if field.required and not (isinstance(field, FileField) and field_value):
                     field.widget.attrs["required"] = ""
                     field.abide_msg = _("This field is required.")
 

--- a/crispy_forms_foundation/forms.py
+++ b/crispy_forms_foundation/forms.py
@@ -67,7 +67,10 @@ class FoundationFormMixin(object):
         # Abide (if enabled)
         if "data_abide" in self.attrs:
             for field_name, field in self.fields.items():
-                field_value = getattr(self.instance, field_name, None)
+                if hasattr(self, 'instance'):
+                    field_value = getattr(self.instance, field_name, None)
+                else:
+                    field_value = None
                 if field.required and not (isinstance(field, FileField) and field_value):
                     field.widget.attrs["required"] = ""
                     field.abide_msg = _("This field is required.")


### PR DESCRIPTION
This fixes issue #37 . When you're editing a model with a FileField that is set to required, if there is a file already saved having `required` in the HTML means it always says `This field is required` regardless. Due to the slightly different way that FileFields work in that we can leave them blank and it won't empty the field, we can simply remove the `required` attribute when the field already has a value.