### PR TITLE
Added support for Django 4.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Links
 Requires
 ========
 
-* `Python`_ >= 3.5;
-* `Django`_ >= 2.0;
+* `Python`_ >= 3.7;
+* `Django`_ >= 3.2;
 * `django-crispy-forms`_ >= 1.8.1;
 * `Foundation for sites`_ >= 6.3.x;

--- a/sandbox/demo/urls.py
+++ b/sandbox/demo/urls.py
@@ -1,7 +1,7 @@
 """
 Urls for "crispy form foundation" demo
 """
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic.base import TemplateView
 
 from .views import (
@@ -12,19 +12,19 @@ from .views import (
 app_name = 'demo'
 
 urlpatterns = [
-    url(r'^foundation-(?P<foundation_version>\d+)/$',
+    re_path(r'^foundation-(?P<foundation_version>\d+)/$',
         FormByFieldsetView.as_view(),
         name='crispy-demo-form-fieldsets'),
-    url(r'^foundation-(?P<foundation_version>\d+)/fieldsets/$',
+    re_path(r'^foundation-(?P<foundation_version>\d+)/fieldsets/$',
         FormByFieldsetView.as_view(),
         name='crispy-demo-form-fieldsets'),
-    url(r'^foundation-(?P<foundation_version>\d+)/tabs/$',
+    re_path(r'^foundation-(?P<foundation_version>\d+)/tabs/$',
         FormByTabView.as_view(),
         name='crispy-demo-form-tabs'),
-    url(r'^foundation-(?P<foundation_version>\d+)/accordions/$',
+    re_path(r'^foundation-(?P<foundation_version>\d+)/accordions/$',
         FormByAccordionView.as_view(),
         name='crispy-demo-form-accordions'),
-    url(r'^foundation-(?P<foundation_version>\d+)/success/$',
+    re_path(r'^foundation-(?P<foundation_version>\d+)/success/$',
         StaticPage.as_view(),
         name='crispy-demo-success'),
 ]

--- a/sandbox/settings/base.py
+++ b/sandbox/settings/base.py
@@ -80,7 +80,9 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
+# RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.
+#    warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)
+# USE_L10N = True
 
 USE_TZ = True
 

--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,7 +1,7 @@
 """
 Sandbox URL Configuration
 """
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 from django.views.generic.base import TemplateView
@@ -9,18 +9,18 @@ from django.views.generic.base import TemplateView
 
 urlpatterns = [
     # Dummy homepage just for simple ping view
-    url(r'^$', TemplateView.as_view(
+    re_path(r'^$', TemplateView.as_view(
         template_name="homepage.html"
     ), name='home'),
 
-     url(r'^crispy-forms/',
+     re_path(r'^crispy-forms/',
          include('sandbox.demo.urls', namespace='demo')),
 ]
 
 try:
     import debug_toolbar
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]
 except ImportError:
     pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = crispy-forms-foundation
-version = 0.8.0
+version = 0.9.0
 description = Django application to add 'django-crispy-forms' layout objects for 'Foundation for sites'
 long_description = file:README.rst
 long_description_content_type = text/x-rst
@@ -16,19 +16,18 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.0
-    Framework :: Django :: 2.1
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
@@ -36,7 +35,7 @@ classifiers =
 [options]
 include_package_data = True
 install_requires =
-    Django>=2.0
+    Django>=3.2
     django-crispy-forms>=1.8.1
 packages = find:
 zip_safe = True
@@ -84,18 +83,17 @@ testpaths =
     tests
 
 [tox:tox]
-envlist = py{36}-django{200,210,220,300}
+envlist = py{37,38,39}-django{320,400,410}
 minversion = 3.4.0
 
 [testenv]
 # Get the right django version following the current env
 deps =
-    django200: Django>=2.0,<2.1
-    django210: Django>=2.1,<2.2
-    django220: Django>=2.2,<2.3
-    django300: Django>=3.0,<3.1
-    django200,django210: django-crispy-forms>=1.8.0,<1.9.0
-    django220,django300: django-crispy-forms>=1.9.0,<2.0.0
+    django320: Django>=3.2,<4.0
+    django400: Django>=4.0,<4.1
+    django410: Django>=4.1,<4.2
+
+    django320,django400,django410: django-crispy-forms>=1.9.0,<2.0.0
 
 commands =
     pip install -e .[dev]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,12 +4,12 @@ import io
 from django.template import Context, Template
 
 import django
-from distutils.version import LooseVersion
 
 
-# Getting Django versions compatibilities
-DJANGO110_COMPAT = LooseVersion(django.get_version()) >= LooseVersion('1.10')
+django_version = django.get_version()
 
+from packaging.version import Version
+DJANGO110_COMPAT = Version(django.get_version()) >= Version('1.10')
 
 def write_output(filepath, pack, filename, content):
     """


### PR DESCRIPTION
tox now passes with Python 3.9 and Django 4.1.2

ERROR:  py37-django320: InterpreterNotFound: python3.7
ERROR:  py37-django400: InterpreterNotFound: python3.7
ERROR:  py37-django410: InterpreterNotFound: python3.7
ERROR:  py38-django320: InterpreterNotFound: python3.8
ERROR:  py38-django400: InterpreterNotFound: python3.8
ERROR:  py38-django410: InterpreterNotFound: python3.8
  py39-django320: commands succeeded
  py39-django400: commands succeeded
  py39-django410: commands succeeded

changes also resolve deprecations

I did not test any 'demo' items