### PR TITLE
Added support for django-crispy-forms 2.0

### DIFF
--- a/crispy_forms_foundation/layout/buttons.py
+++ b/crispy_forms_foundation/layout/buttons.py
@@ -73,13 +73,13 @@ class ButtonGroup(crispy_forms_layout.LayoutObject):
         self.css_id = kwargs.get('css_id', None)
         self.template = kwargs.get('template', self.template)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         field_list = []
         template = self.get_template_name(template_pack)
 
         for field in self.fields:
             field_list.append(
-                render_field(field, form, form_style, context,
+                render_field(field, form, context,
                              template_pack=template_pack)
             )
 
@@ -200,9 +200,9 @@ class ButtonElement(crispy_forms_layout.BaseInput):
         self.content = kwargs.pop('content', None)
         super(ButtonElement, self).__init__(field, *args, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         context['button_content'] = self.content
-        return super(ButtonElement, self).render(form, form_style, context,
+        return super(ButtonElement, self).render(form, context,
                                                  template_pack)
 
 

--- a/crispy_forms_foundation/layout/containers.py
+++ b/crispy_forms_foundation/layout/containers.py
@@ -60,7 +60,7 @@ class Container(crispy_forms_bootstrap.Container):
             return "is-active"
         return self.active_css_class
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK,
+    def render(self, form, context, template_pack=TEMPLATE_PACK,
                **kwargs):
         active_classname = self.get_active_css_class(template_pack)
         if self.active:
@@ -68,7 +68,7 @@ class Container(crispy_forms_bootstrap.Container):
                 self.css_class += ' ' + active_classname
         else:
             self.css_class = self.css_class.replace(active_classname, '')
-        return super(Container, self).render(form, form_style, context,
+        return super(Container, self).render(form, context,
                                              template_pack)
 
 
@@ -98,7 +98,7 @@ class TabHolder(crispy_forms_bootstrap.TabHolder):
     template = "%s/layout/tab-holder.html"
     default_active_tab = None
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         """
         Re-implement almost the same code from crispy_forms but passing
         ``form`` instance to item ``render_link`` method.
@@ -118,7 +118,7 @@ class TabHolder(crispy_forms_bootstrap.TabHolder):
 
         for tab in self.fields:
             content += render_field(
-                tab, form, form_style, context, template_pack=template_pack
+                tab, form, context, template_pack=template_pack
             )
             links += tab.render_link(form, template_pack)
 
@@ -201,7 +201,7 @@ class AccordionHolder(crispy_forms_bootstrap.Accordion):
     """
     template = "%s/layout/accordion-holder.html"
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK,
+    def render(self, form, context, template_pack=TEMPLATE_PACK,
                **kwargs):
         """
         Re-implement almost the same code from crispy_forms but using
@@ -225,7 +225,7 @@ class AccordionHolder(crispy_forms_bootstrap.Accordion):
                                          form.errors.keys()
                                          if fieldname_error in group])
             content += render_field(
-                group, form, form_style, context, template_pack=template_pack,
+                group, form, context, template_pack=template_pack,
                 **kwargs
             )
 

--- a/crispy_forms_foundation/layout/fields.py
+++ b/crispy_forms_foundation/layout/fields.py
@@ -46,9 +46,9 @@ class FakeField(Field):
 
     You should use this field in last resort.
     """
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         context['fake_field'] = True
-        return super(FakeField, self).render(form, form_style, context,
+        return super(FakeField, self).render(form, context,
                                              template_pack)
 
 
@@ -114,7 +114,7 @@ class InlineField(Field):
 
         super(InlineField, self).__init__(field, *args, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         context['label_column'] = self.label_column
         context['input_column'] = self.input_column
         context['label_class'] = self.label_class
@@ -122,7 +122,7 @@ class InlineField(Field):
         html = ''
         template = self.get_template_name(template_pack)
         for field in self.fields:
-            html += render_field(field, form, form_style, context,
+            html += render_field(field, form, context,
                                  template=template, attrs=self.attrs,
                                  template_pack=template_pack)
         return html
@@ -161,9 +161,9 @@ class SwitchField(Field):
 
         super(SwitchField, self).__init__(field, *args, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         context['switch_class'] = " ".join(self.switch_class)
-        return super(SwitchField, self).render(form, form_style, context,
+        return super(SwitchField, self).render(form, context,
                                                template_pack)
 
 
@@ -203,7 +203,7 @@ class InlineSwitchField(InlineField):
 
         super(InlineSwitchField, self).__init__(field, *args, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+    def render(self, form, context, template_pack=TEMPLATE_PACK):
         context['switch_class'] = " ".join(self.switch_class)
-        return super(InlineSwitchField, self).render(form, form_style, context,
+        return super(InlineSwitchField, self).render(form, context,
                                                      template_pack)

--- a/crispy_forms_foundation/templates/foundation-6/layout/fieldset.html
+++ b/crispy_forms_foundation/templates/foundation-6/layout/fieldset.html
@@ -1,4 +1,4 @@
-<fieldset{% if fieldset.css_id %} id="{{ fieldset.css_id }}"{% endif %} class="fieldset{% if fieldset.css_class or form_style %} {{ fieldset.css_class }} {{ form_style }}{% endif %}" {{ fieldset.flat_attrs|safe }}>
+<fieldset{% if fieldset.css_id %} id="{{ fieldset.css_id }}"{% endif %} class="fieldset{% if fieldset.css_class %} {{ fieldset.css_class }} {% endif %}" {{ fieldset.flat_attrs|safe }}>
     <legend>{{ legend|safe }}</legend>
     {{ fields|safe }}
 </fieldset>

--- a/crispy_forms_foundation/templates/foundation-6/uni_form.html
+++ b/crispy_forms_foundation/templates/foundation-6/uni_form.html
@@ -2,14 +2,10 @@
     {% include "foundation-6/errors.html" %}
 {% endif %}
 
-{% if form_style == "" or form_style %}
-    <fieldset class="fieldset {{ form_style }}">
-{% endif %}
+<fieldset class="fieldset">
 
 {% for field in form %}
     {% include field_template|default:"foundation-6/field.html" %}
 {% endfor %}
 
-{% if form_style == "" or form_style %}
-    </fieldset>
-{% endif %}
+</fieldset>

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = crispy-forms-foundation
-version = 0.9.0
+version = 2.0.0
 description = Django application to add 'django-crispy-forms' layout objects for 'Foundation for sites'
 long_description = file:README.rst
 long_description_content_type = text/x-rst
@@ -19,6 +19,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -27,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Internet :: WWW/HTTP
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Software Development :: Libraries :: Python Modules
@@ -35,7 +37,7 @@ classifiers =
 include_package_data = True
 install_requires =
     Django>=3.2
-    django-crispy-forms>=1.8.1
+    django-crispy-forms>=2
 packages = find:
 zip_safe = True
 
@@ -87,7 +89,7 @@ testpaths =
     tests
 
 [tox:tox]
-envlist = py{38,39,310}-django{320,400,410}
+envlist = py{38,39,310,311}-django{320,400,410,420}
 minversion = 3.4.0
 
 [testenv]
@@ -96,8 +98,9 @@ deps =
     django320: Django>=3.2,<4.0
     django400: Django>=4.0,<4.1
     django410: Django>=4.1,<4.2
+    django420: Django>=4.2,<4.3
 
-    django320,django400,django410: django-crispy-forms>=1.9.0,<2.0.0
+    django320,django400,django410,django420: django-crispy-forms>=2.0.0,<3.0.0
 
 commands =
     pip install -e .[test]

--- a/tests/output/foundation-6/test_inlinefield.html
+++ b/tests/output/foundation-6/test_inlinefield.html
@@ -1,2 +1,2 @@
 <form  method="post"><div id="div_id_simple" class="row inline-field"><div class="large-7 columns"><label for="id_simple" class="foobar required">
-                Simple text<span class="asterisk">*</span></label></div><div class="large-5 columns"><input class="textinput textInput" id="id_simple" name="simple" type="text" required /></div></div></form>
+                Simple text<span class="asterisk">*</span></label></div><div class="large-5 columns"><input class="textinput" id="id_simple" name="simple" type="text" required /></div></div></form>


### PR DESCRIPTION
New version of django-crispy-forms 2.0 breaks the package with the following render() error
TypeError: render() missing 1 required positional argument: 'context'

see https://github.com/django-crispy-forms/django-crispy-forms/releases/tag/2.0
<snip>
The uni-form template pack allowed for rendering of templates using a default or inline layout. As the uni-form template
pack has been removed support for this has also been removed. This has resulted in the following BREAKING changes.

    The form_style attribute of FormHelper is removed.
    The form_style positional argument to render_field() is removed.
    The form_style positional argument to the render() method of all LayoutObjects is removed.

Audit for use of render() and render_field() due to the removal of the form_style positional argument is therefore
required. For example:

# django-crispy-forms 1.x
html = my_layout_object.render(form, form_style, context)
# django-crispy-forms 2.x
html = my_layout_object.render(form, context)
</snip>

I've bumped the version to 2.0 simply to come in-line with django-crispy-forms